### PR TITLE
Fix random thinning `PointSets`

### DIFF
--- a/src/thinning/random.jl
+++ b/src/thinning/random.jl
@@ -30,7 +30,7 @@ thin(p::PoissonProcess{<:Function}, t::RandomThinning{<:Real}) = PoissonProcess(
 function thin(pp::PointSet, t::RandomThinning{<:Real})
   draws = rand(Bernoulli(t.p), nelements(pp))
   inds = findall(isequal(1), draws)
-  PointSet(pp.items[inds])
+  view(pp, inds)
 end
 
 function thin(pp::PointSet, t::RandomThinning{<:Function})

--- a/src/thinning/random.jl
+++ b/src/thinning/random.jl
@@ -41,6 +41,5 @@ function thin(pp::PointSet, t::RandomThinning{<:Function})
       push!(inds, j)
     end
   end
-    inds
   PointSet(pp.items[inds])
 end

--- a/src/thinning/random.jl
+++ b/src/thinning/random.jl
@@ -30,16 +30,17 @@ thin(p::PoissonProcess{<:Function}, t::RandomThinning{<:Real}) = PoissonProcess(
 function thin(pp::PointSet, t::RandomThinning{<:Real})
   draws = rand(Bernoulli(t.p), nelements(pp))
   inds = findall(isequal(1), draws)
-  PointSet(coordinates(pp, inds))
+  PointSet(pp.items[inds])
 end
 
 function thin(pp::PointSet, t::RandomThinning{<:Function})
   inds = Vector{Int}()
   for j in 1:nelements(pp)
-    x = coordinates(pp, j)
+    x = element(pp, j)
     if rand(Bernoulli(t.p(x)))
       push!(inds, j)
     end
   end
-  PointSet(coordinates(pp, inds))
+    inds
+  PointSet(pp.items[inds])
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -4,7 +4,10 @@ using GeoStatsBase
 using Test, Random
 
 # list of tests
-testfiles = ["processes.jl"]
+testfiles = [
+  "processes.jl",
+  "thinning.jl"
+]
 
 @testset "PointPatterns.jl" begin
   for testfile in testfiles

--- a/test/thinning.jl
+++ b/test/thinning.jl
@@ -1,0 +1,19 @@
+@testset "Thinning" begin
+  @testset "PointSet" begin
+    p = PoissonProcess(10)
+    q = Quadrangle((0.0, 0.0), (4.0, 0.0), (4.0, 4.0), (0.0, 4.0))
+    pp = rand(p, q)
+    tp = thin(pp, RandomThinning(0.3))
+    @test length(tp) ≤ length(pp)
+    xs = coordinates.(tp)
+    @test all(0 .≤ first.(xs) .≤ 4.0)
+    @test all(0 .≤ last.(xs) .≤ 4.0)
+
+    λ(s::Point2) = sum(coordinates(s) .^ 2)
+    tp = thin(pp, RandomThinning(s -> λ(s) / λ(Point(4.0,4.0))))
+    @test length(tp) ≤ length(pp)
+    xs = coordinates.(tp)
+    @test all(0 .≤ first.(xs) .≤ 4.0)
+    @test all(0 .≤ last.(xs) .≤ 4.0)
+  end
+end


### PR DESCRIPTION
Random thinning a `PointSet` is not working for `RandomThinning{<:Real}` and `RandomThinning{<:Function}`. It produces the following errors:
```julia
# ERROR: MethodError: no method matching coordinates(::PointSet{2, Float64}, ::Vector{Int64})
# ERROR: MethodError: no method matching coordinates(::PointSet{2, Float64}, ::Int64)
```
I image that it was an old `Meshes.jl` behaviour. This PR fixes that issue and add tests for random thinning.