### PR TITLE
Inhomogeneous

### DIFF
--- a/src/PointPatterns.jl
+++ b/src/PointPatterns.jl
@@ -30,6 +30,7 @@ export
   thin,
 
   # sampling methods
-  ThinnedSampling
+  ThinnedSampling,
+  SimpleThinnedSampling
 
 end # module

--- a/src/PointPatterns.jl
+++ b/src/PointPatterns.jl
@@ -11,8 +11,6 @@ using Distributions
 
 import Random
 
-# MyStruct{Point}() where T = MyStruct{T}(nothing)
-
 include("processes.jl")
 include("thinning.jl")
 

--- a/src/PointPatterns.jl
+++ b/src/PointPatterns.jl
@@ -11,8 +11,6 @@ using Distributions
 
 import Random
 
-const GeometryOrMesh = Union{Geometry,Mesh}
-
 include("processes.jl")
 include("thinning.jl")
 

--- a/src/PointPatterns.jl
+++ b/src/PointPatterns.jl
@@ -30,6 +30,7 @@ export
   thin,
 
   # sampling methods
+  DiscretizedSampling,
   ThinnedSampling,
   SimpleThinnedSampling
 

--- a/src/PointPatterns.jl
+++ b/src/PointPatterns.jl
@@ -11,6 +11,8 @@ using Distributions
 
 import Random
 
+# MyStruct{Point}() where T = MyStruct{T}(nothing)
+
 include("processes.jl")
 include("thinning.jl")
 

--- a/src/PointPatterns.jl
+++ b/src/PointPatterns.jl
@@ -11,6 +11,8 @@ using Distributions
 
 import Random
 
+const GeometryOrMesh = Union{Geometry,Mesh}
+
 include("processes.jl")
 include("thinning.jl")
 

--- a/src/PointPatterns.jl
+++ b/src/PointPatterns.jl
@@ -25,6 +25,9 @@ export
   # thinning methods
   AbstractThinning,
   RandomThinning,
-  thin
+  thin,
+
+  # sampling methods
+  ThinnedSampling
 
 end # module

--- a/src/PointPatterns.jl
+++ b/src/PointPatterns.jl
@@ -29,7 +29,6 @@ export
 
   # sampling methods
   DiscretizedSampling,
-  ThinnedSampling,
-  SimpleThinnedSampling
+  ThinnedSampling
 
 end # module

--- a/src/PointPatterns.jl
+++ b/src/PointPatterns.jl
@@ -25,10 +25,6 @@ export
   # thinning methods
   AbstractThinning,
   RandomThinning,
-  thin,
-
-  # sampling methods
-  DiscretizedSampling,
-  ThinnedSampling
+  thin
 
 end # module

--- a/src/processes.jl
+++ b/src/processes.jl
@@ -23,16 +23,16 @@ Generate `n` realizations of spatial point process `p`
 inside geometry `g`. Optionally specify sampling
 algorithm `algo` and random number generator `rng`.
 """
-Base.rand(rng::Random.AbstractRNG, p::PointProcess, g::GeometryOrMesh, n::Int; algo=default_sampling_algorithm(p, g)) =
+Base.rand(rng::Random.AbstractRNG, p::PointProcess, g, n::Int; algo=default_sampling_algorithm(p, g)) =
   [rand_single(rng, p, g, algo) for i in 1:n]
 
-Base.rand(rng::Random.AbstractRNG, p::PointProcess, g::GeometryOrMesh; algo=default_sampling_algorithm(p, g)) =
+Base.rand(rng::Random.AbstractRNG, p::PointProcess, g; algo=default_sampling_algorithm(p, g)) =
   rand_single(rng, p, g, algo)
 
-Base.rand(p::PointProcess, g::GeometryOrMesh, n::Int; algo=default_sampling_algorithm(p, g)) =
+Base.rand(p::PointProcess, g, n::Int; algo=default_sampling_algorithm(p, g)) =
   rand(Random.GLOBAL_RNG, p, g, n; algo=algo)
 
-Base.rand(p::PointProcess, g::GeometryOrMesh; algo=default_sampling_algorithm(p, g)) =
+Base.rand(p::PointProcess, g; algo=default_sampling_algorithm(p, g)) =
   rand(Random.GLOBAL_RNG, p, g; algo=algo)
 
 """
@@ -64,8 +64,8 @@ struct UnionSampling end
 Generate sample using Lewis-Shedler algorithm (1979) with
 maximum value of the intensity function `λmax`.
 """
-struct ThinnedSampling
-  λmax::Real
+struct ThinnedSampling{T<:Real}
+  λmax::T
 end
 
 #-----------------

--- a/src/processes.jl
+++ b/src/processes.jl
@@ -67,6 +67,20 @@ struct ThinnedSampling{T<:Real}
   λmax::T
 end
 
+"""
+    SimpleThinnedSampling(dims)
+
+Generate sample using Lewis-Shedler algorithm (1979). The
+maximum value of the intensity function is computed using a
+CartesianGrid of size `dims`. Increase the `dims` size in case
+the sampling throws error.
+"""
+struct SimpleThinnedSampling
+  dims::Union{Dims,Nothing}
+end
+
+SimpleThinnedSampling() = SimpleThinnedSampling(nothing)
+
 #-----------------
 # IMPLEMENTATIONS
 #-----------------

--- a/src/processes.jl
+++ b/src/processes.jl
@@ -56,15 +56,6 @@ function default_sampling_algorithm end
 # --------------------
 
 """
-    DiscretizedSampling()
-
-Generate sample assuming the intensity is constant over a `Geometry`
-or piecewise constant over a `Domain`.
-"""
-struct DiscretizedSampling end
-struct UnionSampling end
-
-"""
     ThinnedSampling(λmax)
 
 Generate sample using Lewis-Shedler algorithm (1979) with
@@ -73,6 +64,16 @@ maximum real value `λmax` of the intensity function.
 struct ThinnedSampling{T<:Real}
   λmax::T
 end
+
+"""
+    DiscretizedSampling()
+
+Generate sample assuming the intensity is constant over a `Geometry`
+or piecewise constant over a `Domain`.
+"""
+struct DiscretizedSampling end
+
+struct UnionSampling end
 
 #-----------------
 # IMPLEMENTATIONS

--- a/src/processes.jl
+++ b/src/processes.jl
@@ -23,16 +23,16 @@ Generate `n` realizations of spatial point process `p`
 inside geometry `g`. Optionally specify sampling
 algorithm `algo` and random number generator `rng`.
 """
-Base.rand(rng::Random.AbstractRNG, p::PointProcess, g::Geometry, n::Int; algo=default_sampling_algorithm(p, g)) =
+Base.rand(rng::Random.AbstractRNG, p::PointProcess, g::GeometryOrMesh, n::Int; algo=default_sampling_algorithm(p, g)) =
   [rand_single(rng, p, g, algo) for i in 1:n]
 
-Base.rand(rng::Random.AbstractRNG, p::PointProcess, g::Geometry; algo=default_sampling_algorithm(p, g)) =
+Base.rand(rng::Random.AbstractRNG, p::PointProcess, g::GeometryOrMesh; algo=default_sampling_algorithm(p, g)) =
   rand_single(rng, p, g, algo)
 
-Base.rand(p::PointProcess, g::Geometry, n::Int; algo=default_sampling_algorithm(p, g)) =
+Base.rand(p::PointProcess, g::GeometryOrMesh, n::Int; algo=default_sampling_algorithm(p, g)) =
   rand(Random.GLOBAL_RNG, p, g, n; algo=algo)
 
-Base.rand(p::PointProcess, g::Geometry; algo=default_sampling_algorithm(p, g)) =
+Base.rand(p::PointProcess, g::GeometryOrMesh; algo=default_sampling_algorithm(p, g)) =
   rand(Random.GLOBAL_RNG, p, g; algo=algo)
 
 """

--- a/src/processes.jl
+++ b/src/processes.jl
@@ -54,6 +54,12 @@ function default_sampling_algorithm end
 # SAMPLING ALGORITHMS
 # --------------------
 
+"""
+    DiscretizedSampling()
+
+Generate sample assuming the intensity is constant over a `Geometry`
+or piecewise constant over a `Domain`.
+"""
 struct DiscretizedSampling end
 struct UnionSampling end
 

--- a/src/processes.jl
+++ b/src/processes.jl
@@ -23,16 +23,16 @@ Generate `n` realizations of spatial point process `p`
 inside geometry `g`. Optionally specify sampling
 algorithm `algo` and random number generator `rng`.
 """
-Base.rand(rng::Random.AbstractRNG, p::PointProcess, g, n::Int; algo=default_sampling_algorithm(p)) =
+Base.rand(rng::Random.AbstractRNG, p::PointProcess, g, n::Int; algo=default_sampling_algorithm(p, g)) =
   [rand_single(rng, p, g, algo) for i in 1:n]
 
-Base.rand(rng::Random.AbstractRNG, p::PointProcess, g; algo=default_sampling_algorithm(p)) =
+Base.rand(rng::Random.AbstractRNG, p::PointProcess, g; algo=default_sampling_algorithm(p, g)) =
   rand_single(rng, p, g, algo)
 
-Base.rand(p::PointProcess, g, n::Int; algo=default_sampling_algorithm(p)) =
+Base.rand(p::PointProcess, g, n::Int; algo=default_sampling_algorithm(p, g)) =
   rand(Random.GLOBAL_RNG, p, g, n; algo=algo)
 
-Base.rand(p::PointProcess, g; algo=default_sampling_algorithm(p)) =
+Base.rand(p::PointProcess, g; algo=default_sampling_algorithm(p, g)) =
   rand(Random.GLOBAL_RNG, p, g; algo=algo)
 
 """
@@ -58,18 +58,14 @@ struct DiscretizedSampling end
 struct UnionSampling end
 
 """
-    ThinnedSampling(param)
+    ThinnedSampling(λmax)
 
-Generate sample using Lewis-Shedler algorithm (1979) using `param`.
-It can be a real value to define the maximum value of the intensity
-function or an `NTuple` to define the dimensions of the
-`CartesianGrid` used to obtain the intensity maximum value.
+Generate sample using Lewis-Shedler algorithm (1979) with
+maximum real value `λmax` of the intensity function.
 """
-struct ThinnedSampling{T<:Union{Real,Dims}}
-  param::Union{Nothing,T}
+struct ThinnedSampling{T<:Real}
+  λmax::T
 end
-
-ThinnedSampling() = ThinnedSampling{Dims}(nothing)
 
 #-----------------
 # IMPLEMENTATIONS

--- a/src/processes.jl
+++ b/src/processes.jl
@@ -44,9 +44,10 @@ Generate a single realization of spatial point process
 function rand_single end
 
 """
-    default_sampling_algorithm(p)
+    default_sampling_algorithm(p, g)
 
-Default sampling algorithm for spatial point process `p`.
+Default sampling algorithm for spatial point process `p`
+on geometry or domain `g`.
 """
 function default_sampling_algorithm end
 

--- a/src/processes.jl
+++ b/src/processes.jl
@@ -72,8 +72,8 @@ end
 
 Generate sample using Lewis-Shedler algorithm (1979). The
 maximum value of the intensity function is computed using a
-CartesianGrid of size `dims`. Increase the `dims` size in case
-the sampling throws error.
+CartesianGrid of size `dims`. Increase the values of `dims`
+in case the sampling throws an error.
 """
 struct SimpleThinnedSampling
   dims::Union{Dims,Nothing}

--- a/src/processes.jl
+++ b/src/processes.jl
@@ -23,16 +23,16 @@ Generate `n` realizations of spatial point process `p`
 inside geometry `g`. Optionally specify sampling
 algorithm `algo` and random number generator `rng`.
 """
-Base.rand(rng::Random.AbstractRNG, p::PointProcess, g, n::Int; algo=default_sampling_algorithm(p, g)) =
+Base.rand(rng::Random.AbstractRNG, p::PointProcess, g, n::Int; algo=default_sampling_algorithm(p)) =
   [rand_single(rng, p, g, algo) for i in 1:n]
 
-Base.rand(rng::Random.AbstractRNG, p::PointProcess, g; algo=default_sampling_algorithm(p, g)) =
+Base.rand(rng::Random.AbstractRNG, p::PointProcess, g; algo=default_sampling_algorithm(p)) =
   rand_single(rng, p, g, algo)
 
-Base.rand(p::PointProcess, g, n::Int; algo=default_sampling_algorithm(p, g)) =
+Base.rand(p::PointProcess, g, n::Int; algo=default_sampling_algorithm(p)) =
   rand(Random.GLOBAL_RNG, p, g, n; algo=algo)
 
-Base.rand(p::PointProcess, g; algo=default_sampling_algorithm(p, g)) =
+Base.rand(p::PointProcess, g; algo=default_sampling_algorithm(p)) =
   rand(Random.GLOBAL_RNG, p, g; algo=algo)
 
 """
@@ -44,10 +44,9 @@ Generate a single realization of spatial point process
 function rand_single end
 
 """
-    default_sampling_algorithm(p, g)
+    default_sampling_algorithm(p)
 
-Default sampling algorithm for spatial point process `p`
-on geometry `g`.
+Default sampling algorithm for spatial point process `p`.
 """
 function default_sampling_algorithm end
 

--- a/src/processes.jl
+++ b/src/processes.jl
@@ -58,28 +58,18 @@ struct DiscretizedSampling end
 struct UnionSampling end
 
 """
-    ThinnedSampling(λmax)
+    ThinnedSampling(param)
 
-Generate sample using Lewis-Shedler algorithm (1979) with
-maximum value of the intensity function `λmax`.
+Generate sample using Lewis-Shedler algorithm (1979) using `param`.
+It can be a real value to define the maximum value of the intensity
+function or an `NTuple` to define the dimensions of the
+`CartesianGrid` used to obtain the intensity maximum value.
 """
-struct ThinnedSampling{T<:Real}
-  λmax::T
+struct ThinnedSampling{T<:Union{Real,Dims}}
+  param::Union{Nothing,T}
 end
 
-"""
-    SimpleThinnedSampling(dims)
-
-Generate sample using Lewis-Shedler algorithm (1979). The
-maximum value of the intensity function is computed using a
-CartesianGrid of size `dims`. Increase the values of `dims`
-in case the sampling throws an error.
-"""
-struct SimpleThinnedSampling
-  dims::Union{Dims,Nothing}
-end
-
-SimpleThinnedSampling() = SimpleThinnedSampling(nothing)
+ThinnedSampling() = ThinnedSampling{Dims}(nothing)
 
 #-----------------
 # IMPLEMENTATIONS

--- a/src/processes.jl
+++ b/src/processes.jl
@@ -55,7 +55,6 @@ function default_sampling_algorithm end
 # SAMPLING ALGORITHMS
 # --------------------
 
-struct ProductSampling end
 struct DiscretizedSampling end
 struct UnionSampling end
 

--- a/src/processes.jl
+++ b/src/processes.jl
@@ -56,9 +56,18 @@ function default_sampling_algorithm end
 # --------------------
 
 struct ProductSampling end
-struct ThinnedSampling end
 struct DiscretizedSampling end
 struct UnionSampling end
+
+"""
+    ThinnedSampling(λmax)
+
+Generate sample using Lewis-Shedler algorithm (1979) with
+maximum value of the intensity function `λmax`.
+"""
+struct ThinnedSampling
+  λmax::Real
+end
 
 #-----------------
 # IMPLEMENTATIONS

--- a/src/processes/binomial.jl
+++ b/src/processes/binomial.jl
@@ -13,15 +13,9 @@ end
 
 ishomogeneous(p::BinomialProcess) = true
 
-default_sampling_algorithm(::BinomialProcess, ::Geometry) = ProductSampling()
+default_sampling_algorithm(::BinomialProcess, ::GeometryOrMesh) = DiscretizedSampling()
 
-function rand_single(rng::Random.AbstractRNG, p::BinomialProcess, b::Box{Dim,T}, ::ProductSampling) where {Dim,T}
-  # region configuration
-  lo, up = coordinates.(extrema(b))
-
-  # product of uniform distributions
-  U = product_distribution([Uniform(lo[i], up[i]) for i in 1:Dim])
-
-  # return point pattern
-  PointSet(rand(rng, U, p.n))
+function rand_single(rng::Random.AbstractRNG, p::BinomialProcess, g::GeometryOrMesh, ::DiscretizedSampling)
+  pts = sample(g, HomogeneousSampling(p.n))
+  PointSet(collect(pts))
 end

--- a/src/processes/binomial.jl
+++ b/src/processes/binomial.jl
@@ -16,6 +16,6 @@ ishomogeneous(p::BinomialProcess) = true
 default_sampling_algorithm(::BinomialProcess) = DiscretizedSampling()
 
 function rand_single(rng::Random.AbstractRNG, p::BinomialProcess, g, ::DiscretizedSampling)
-  pts = sample(g, HomogeneousSampling(p.n))
-  PointSet(collect(pts))
+  points = sample(g, HomogeneousSampling(p.n))
+  PointSet(collect(points))
 end

--- a/src/processes/binomial.jl
+++ b/src/processes/binomial.jl
@@ -13,7 +13,7 @@ end
 
 ishomogeneous(p::BinomialProcess) = true
 
-default_sampling_algorithm(::BinomialProcess) = DiscretizedSampling()
+default_sampling_algorithm(::BinomialProcess, g) = DiscretizedSampling()
 
 function rand_single(rng::Random.AbstractRNG, p::BinomialProcess, g, ::DiscretizedSampling)
   points = sample(g, HomogeneousSampling(p.n))

--- a/src/processes/binomial.jl
+++ b/src/processes/binomial.jl
@@ -15,7 +15,7 @@ ishomogeneous(p::BinomialProcess) = true
 
 default_sampling_algorithm(::BinomialProcess, ::Any) = DiscretizedSampling()
 
-function rand_single(rng::Random.AbstractRNG, p::BinomialProcess, g::GeometryOrMesh, ::DiscretizedSampling)
+function rand_single(rng::Random.AbstractRNG, p::BinomialProcess, g, ::DiscretizedSampling)
   pts = sample(g, HomogeneousSampling(p.n))
   PointSet(collect(pts))
 end

--- a/src/processes/binomial.jl
+++ b/src/processes/binomial.jl
@@ -13,7 +13,7 @@ end
 
 ishomogeneous(p::BinomialProcess) = true
 
-default_sampling_algorithm(::BinomialProcess, ::Any) = DiscretizedSampling()
+default_sampling_algorithm(::BinomialProcess) = DiscretizedSampling()
 
 function rand_single(rng::Random.AbstractRNG, p::BinomialProcess, g, ::DiscretizedSampling)
   pts = sample(g, HomogeneousSampling(p.n))

--- a/src/processes/binomial.jl
+++ b/src/processes/binomial.jl
@@ -13,7 +13,7 @@ end
 
 ishomogeneous(p::BinomialProcess) = true
 
-default_sampling_algorithm(::BinomialProcess, ::GeometryOrMesh) = DiscretizedSampling()
+default_sampling_algorithm(::BinomialProcess, ::Any) = DiscretizedSampling()
 
 function rand_single(rng::Random.AbstractRNG, p::BinomialProcess, g::GeometryOrMesh, ::DiscretizedSampling)
   pts = sample(g, HomogeneousSampling(p.n))

--- a/src/processes/binomial.jl
+++ b/src/processes/binomial.jl
@@ -13,7 +13,7 @@ end
 
 ishomogeneous(p::BinomialProcess) = true
 
-default_sampling_algorithm(::BinomialProcess, g) = DiscretizedSampling()
+default_sampling_algorithm(::BinomialProcess, ::Any) = DiscretizedSampling()
 
 function rand_single(rng::Random.AbstractRNG, p::BinomialProcess, g, ::DiscretizedSampling)
   points = sample(g, HomogeneousSampling(p.n))

--- a/src/processes/binomial.jl
+++ b/src/processes/binomial.jl
@@ -17,5 +17,5 @@ default_sampling_algorithm(::BinomialProcess) = DiscretizedSampling()
 
 function rand_single(rng::Random.AbstractRNG, p::BinomialProcess, g, ::DiscretizedSampling)
   points = sample(g, HomogeneousSampling(p.n))
-  PointSet(collect(points))
+  PointSet(points)
 end

--- a/src/processes/poisson.jl
+++ b/src/processes/poisson.jl
@@ -28,7 +28,7 @@ Base.union(p₁::PoissonProcess{<:AbstractVector}, p₂::PoissonProcess{<:Abstra
 
 ishomogeneous(p::PoissonProcess{<:Real}) = true
 ishomogeneous(p::PoissonProcess{<:Function}) = false
-ishomogeneous(p::PoissonProcess{<:Vector}) = false
+ishomogeneous(p::PoissonProcess{<:AbstractVector}) = false
 
 default_sampling_algorithm(::PoissonProcess, g) = DiscretizedSampling()
 default_sampling_algorithm(p::PoissonProcess{<:Function}, g) = ThinnedSampling(default_lambda_max(p, g))
@@ -65,7 +65,7 @@ end
 # INHOMOGENEOUS CASE
 #--------------------
 
-function rand_single(rng::Random.AbstractRNG, p::PoissonProcess{<:Vector}, d::Domain, algo::DiscretizedSampling)
+function rand_single(rng::Random.AbstractRNG, p::PoissonProcess{<:AbstractVector}, d::Domain, algo::DiscretizedSampling)
   # simulate number of points
   λ = p.λ
   V = measure.(d)

--- a/src/processes/poisson.jl
+++ b/src/processes/poisson.jl
@@ -36,7 +36,7 @@ default_sampling_algorithm(::PoissonProcess, ::GeometryOrMesh) = DiscretizedSamp
 # HOMOGENEOUS CASE
 #------------------
 
-function rand_single(rng::Random.AbstractRNG, p::PoissonProcess{<:Real}, g::GeometryOrMesh, ::DiscretizedSampling)
+function rand_single(rng::Random.AbstractRNG, p::PoissonProcess{<:Real}, g, ::DiscretizedSampling)
   # simulate number of points
   λ = p.λ
   V = measure(g)
@@ -80,7 +80,7 @@ function rand_single(rng::Random.AbstractRNG, p::PoissonProcess{<:Function}, g::
   rand_single(rng, PoissonProcess(λvec), g, DiscretizedSampling())
 end
 
-function rand_single(rng::Random.AbstractRNG, p::PoissonProcess{<:Function}, g::GeometryOrMesh, algo::ThinnedSampling)
+function rand_single(rng::Random.AbstractRNG, p::PoissonProcess{<:Function}, g, algo::ThinnedSampling)
   # simulate a homogeneous process
   pp = rand(rng, PoissonProcess(algo.λmax), g)
 

--- a/src/processes/poisson.jl
+++ b/src/processes/poisson.jl
@@ -24,7 +24,7 @@ Base.union(p₁::PoissonProcess{<:Real}, p₂::PoissonProcess{<:Function}) = Poi
 
 Base.union(p₁::PoissonProcess{<:Function}, p₂::PoissonProcess{<:Real}) = PoissonProcess(x -> p₁.λ(x) + p₂.λ)
 
-Base.union(p₁::PoissonProcess{<:Vector}, p₂::PoissonProcess{<:Vector}) = PoissonProcess(x -> p₁.λ + p₂.λ)
+Base.union(p₁::PoissonProcess{<:AbstractVector}, p₂::PoissonProcess{<:AbstractVector}) = PoissonProcess(x -> p₁.λ + p₂.λ)
 
 ishomogeneous(p::PoissonProcess{<:Real}) = true
 ishomogeneous(p::PoissonProcess{<:Function}) = false

--- a/src/processes/poisson.jl
+++ b/src/processes/poisson.jl
@@ -44,6 +44,7 @@ function rand_single(rng::Random.AbstractRNG, p::PoissonProcess{<:Real}, g, ::Di
   n = rand(rng, Poisson(λ * V))
 
   if n == 0
+    # PointSet{embeddim(g), coordtype(g)}([])
     nothing
   else
     # simulate homogeneous process
@@ -75,15 +76,16 @@ function rand_single(rng::Random.AbstractRNG, p::PoissonProcess{<:Vector}, m::Me
   PointSet(collect(pts))
 end
 
-function rand_single(rng::Random.AbstractRNG, p::PoissonProcess{<:Function}, g::Geometry, algo::DiscretizedSampling)
-  # discretize region
-  g = discretize(g)
-  m = centroid.(g)
-  λvec = p.λ.(m)
-
-  # sample point pattern
-  rand_single(rng, PoissonProcess(λvec), g, DiscretizedSampling())
+function rand_single(rng::Random.AbstractRNG, p::PoissonProcess{<:Function}, m::Mesh, algo::DiscretizedSampling)
+  c = centroid.(m)
+  λvec = p.λ.(c)
+  rand_single(rng, PoissonProcess(λvec), m, algo)
 end
+
+# function rand_single(rng::Random.AbstractRNG, p::PoissonProcess{<:Function}, g::Geometry, algo::DiscretizedSampling)
+#   g = discretize(g)
+#   rand_single(rng, p, g, algo)
+# end
 
 function rand_single(rng::Random.AbstractRNG, p::PoissonProcess{<:Function}, g, algo::ThinnedSampling)
   # simulate a homogeneous process

--- a/src/processes/poisson.jl
+++ b/src/processes/poisson.jl
@@ -43,11 +43,15 @@ function rand_single(rng::Random.AbstractRNG, p::PoissonProcess{<:Real}, g, ::Di
   V = measure(g)
   n = rand(rng, Poisson(λ * V))
 
-  # simulate homogeneous process
-  pts = sample(g, HomogeneousSampling(n))
+  if n == 0
+    nothing
+  else
+    # simulate homogeneous process
+    pts = sample(g, HomogeneousSampling(n))
 
-  # return point pattern
-  PointSet(collect(pts))
+    # return point pattern
+    PointSet(collect(pts))
+  end
 end
 
 #--------------------

--- a/src/processes/poisson.jl
+++ b/src/processes/poisson.jl
@@ -89,7 +89,7 @@ end
 
 function rand_single(rng::Random.AbstractRNG, p::PoissonProcess{<:Function}, g, algo::ThinnedSampling)
   # simulate a homogeneous process
-  pp = rand(rng, PoissonProcess(algo.λmax), g)
+  pp = rand_single(rng, PoissonProcess(algo.λmax), g, DiscretizedSampling())
 
   # thin point pattern
   thin(pp, RandomThinning(x -> p.λ(x) / algo.λmax))

--- a/src/processes/poisson.jl
+++ b/src/processes/poisson.jl
@@ -59,7 +59,7 @@ end
 
 function rand_single(rng::Random.AbstractRNG, p::PoissonProcess{<:Function}, g::Geometry, algo::ThinnedSampling)
   # simulate a homogeneous process
-  pp = rand_single(rng, PoissonProcess(algo.λmax), g, DiscretizedSampling())
+  pp = rand(rng, PoissonProcess(algo.λmax), g)
 
   # thin point pattern
   thin(pp, RandomThinning(x -> p.λ(x) / algo.λmax))

--- a/src/processes/poisson.jl
+++ b/src/processes/poisson.jl
@@ -23,7 +23,6 @@ ishomogeneous(p::PoissonProcess{<:Real}) = true
 ishomogeneous(p::PoissonProcess{<:Function}) = false
 
 default_sampling_algorithm(::PoissonProcess, ::Geometry) = DiscretizedSampling()
-default_sampling_algorithm(::PoissonProcess{<:Real}, ::Box) = ProductSampling()
 
 #------------------
 # HOMOGENEOUS CASE

--- a/src/processes/poisson.jl
+++ b/src/processes/poisson.jl
@@ -6,8 +6,8 @@
    PoissonProcess(λ)
 
 A Poisson process with intensity `λ`. For a homogeneous process,
-define `λ` a constant value, while for an inhomogeneous process,
-define `λ` as a function or vector. If `λ` is a vector, it is
+define `λ` as a constant value, while for an inhomogeneous process,
+define `λ` as a Function or Vector. If `λ` is a vector, it is
 assumed that the process is associated with a `Mesh` with the same
 number of elements as `λ`.
 """

--- a/src/processes/poisson.jl
+++ b/src/processes/poisson.jl
@@ -6,9 +6,9 @@
    PoissonProcess(λ)
 
 A Poisson process with intensity `λ`. For a homogeneous process,
-define `λ` as a constant value, while for an inhomogeneous process,
-define `λ` as a Function or Vector. If `λ` is a vector, it is
-assumed that the process is associated with a `Mesh` with the same
+define `λ` as a constant real value, while for an inhomogeneous process,
+define `λ` as a function or vector of values. If `λ` is a vector, it is
+assumed that the process is associated with a `Domain` with the same
 number of elements as `λ`.
 """
 

--- a/src/processes/poisson.jl
+++ b/src/processes/poisson.jl
@@ -52,14 +52,3 @@ function rand_single(rng::Random.AbstractRNG, p::PoissonProcess{<:Function}, g::
   # thin point pattern
   thin(pp, RandomThinning(x -> p.λ(x) / algo.λmax))
 end
-
-# function rand_single(rng::Random.AbstractRNG, p::PoissonProcess{<:Function}, b::Box, algo::DiscretizedSampling)
-#   # discretize region
-#   # TODO
-#
-#   # discretize retention
-#   # TODO
-#
-#   # sample each element
-#   # TODO
-# end

--- a/src/processes/poisson.jl
+++ b/src/processes/poisson.jl
@@ -12,7 +12,7 @@ assumed that the process is associated with a `Domain` with the same
 number of elements as `λ`.
 """
 
-struct PoissonProcess{L<:Union{Real,Function,Vector}} <: PointProcess
+struct PoissonProcess{L<:Union{Real,Function,AbstractVector}} <: PointProcess
   λ::L
 end
 

--- a/src/processes/poisson.jl
+++ b/src/processes/poisson.jl
@@ -5,8 +5,13 @@
 """
    PoissonProcess(λ)
 
-A Poisson process with intensity `λ`.
+A Poisson process with intensity `λ`. For a homogeneous process,
+define `λ` a constant value, while for an inhomogeneous process,
+define `λ` as a function or vector. If `λ` is a vector, it is
+assumed that the process is associated with a `Mesh` with the same
+number of elements as `λ`.
 """
+
 struct PoissonProcess{L<:Union{Real,Function,Vector}} <: PointProcess
   λ::L
 end

--- a/src/processes/poisson.jl
+++ b/src/processes/poisson.jl
@@ -42,22 +42,6 @@ function rand_single(rng::Random.AbstractRNG, p::PoissonProcess{<:Real}, g::Geom
   PointSet(collect(pts))
 end
 
-function rand_single(rng::Random.AbstractRNG, p::PoissonProcess{<:Real}, b::Box, ::ProductSampling)
-  # region configuration
-  lo, up = coordinates.(extrema(b))
-
-  # simulate number of points
-  λ = p.λ
-  V = measure(b)
-  n = rand(rng, Poisson(λ * V))
-
-  # product of uniform distributions
-  U = product_distribution([Uniform(lo[i], up[i]) for i in 1:embeddim(b)])
-
-  # return point pattern
-  PointSet(rand(rng, U, n))
-end
-
 #--------------------
 # INHOMOGENEOUS CASE
 #--------------------
@@ -73,7 +57,10 @@ function rand_single(rng::Random.AbstractRNG, p::PoissonProcess{<:Function}, b::
   # TODO
 end
 
-function rand_single(rng::Random.AbstractRNG, p::PoissonProcess{<:Function}, b::Box, algo::ThinnedSampling)
-  # Lewis-Shedler algorithm
-  # TODO
+function rand_single(rng::Random.AbstractRNG, p::PoissonProcess{<:Function}, g::Geometry, algo::ThinnedSampling)
+  # simulate a homogeneous process
+  pp = rand_single(rng, PoissonProcess(algo.λmax), g, DiscretizedSampling())
+
+  # thin point pattern
+  thin(pp, RandomThinning(x -> p.λ(x) / algo.λmax))
 end

--- a/src/processes/poisson.jl
+++ b/src/processes/poisson.jl
@@ -30,7 +30,8 @@ ishomogeneous(p::PoissonProcess{<:Real}) = true
 ishomogeneous(p::PoissonProcess{<:Function}) = false
 ishomogeneous(p::PoissonProcess{<:Vector}) = false
 
-default_sampling_algorithm(::PoissonProcess, ::GeometryOrMesh) = DiscretizedSampling()
+default_sampling_algorithm(::PoissonProcess, ::Any) = DiscretizedSampling()
+default_sampling_algorithm(::PoissonProcess{<:Function}, ::Any) = ThinnedSampling()
 
 #------------------
 # HOMOGENEOUS CASE

--- a/src/processes/poisson.jl
+++ b/src/processes/poisson.jl
@@ -22,13 +22,13 @@ Base.union(p₁::PoissonProcess{<:Function}, p₂::PoissonProcess{<:Real}) = Poi
 ishomogeneous(p::PoissonProcess{<:Real}) = true
 ishomogeneous(p::PoissonProcess{<:Function}) = false
 
-default_sampling_algorithm(::PoissonProcess, ::Geometry) = DiscretizedSampling()
+default_sampling_algorithm(::PoissonProcess, ::GeometryOrMesh) = DiscretizedSampling()
 
 #------------------
 # HOMOGENEOUS CASE
 #------------------
 
-function rand_single(rng::Random.AbstractRNG, p::PoissonProcess{<:Real}, g::Geometry, ::DiscretizedSampling)
+function rand_single(rng::Random.AbstractRNG, p::PoissonProcess{<:Real}, g::GeometryOrMesh, ::DiscretizedSampling)
   # simulate number of points
   λ = p.λ
   V = measure(g)
@@ -45,21 +45,21 @@ end
 # INHOMOGENEOUS CASE
 #--------------------
 
-function rand_single(rng::Random.AbstractRNG, p::PoissonProcess{<:Function}, b::Box, algo::DiscretizedSampling)
-  # discretize region
-  # TODO
-
-  # discretize retention
-  # TODO
-
-  # sample each element
-  # TODO
-end
-
-function rand_single(rng::Random.AbstractRNG, p::PoissonProcess{<:Function}, g::Geometry, algo::ThinnedSampling)
+function rand_single(rng::Random.AbstractRNG, p::PoissonProcess{<:Function}, g::GeometryOrMesh, algo::ThinnedSampling)
   # simulate a homogeneous process
   pp = rand(rng, PoissonProcess(algo.λmax), g)
 
   # thin point pattern
   thin(pp, RandomThinning(x -> p.λ(x) / algo.λmax))
 end
+
+# function rand_single(rng::Random.AbstractRNG, p::PoissonProcess{<:Function}, b::Box, algo::DiscretizedSampling)
+#   # discretize region
+#   # TODO
+#
+#   # discretize retention
+#   # TODO
+#
+#   # sample each element
+#   # TODO
+# end

--- a/src/processes/poisson.jl
+++ b/src/processes/poisson.jl
@@ -24,8 +24,11 @@ Base.union(p₁::PoissonProcess{<:Real}, p₂::PoissonProcess{<:Function}) = Poi
 
 Base.union(p₁::PoissonProcess{<:Function}, p₂::PoissonProcess{<:Real}) = PoissonProcess(x -> p₁.λ(x) + p₂.λ)
 
+Base.union(p₁::PoissonProcess{<:Vector}, p₂::PoissonProcess{<:Vector}) = PoissonProcess(x -> p₁.λ + p₂.λ)
+
 ishomogeneous(p::PoissonProcess{<:Real}) = true
 ishomogeneous(p::PoissonProcess{<:Function}) = false
+ishomogeneous(p::PoissonProcess{<:Vector}) = false
 
 default_sampling_algorithm(::PoissonProcess, ::GeometryOrMesh) = DiscretizedSampling()
 

--- a/src/processes/poisson.jl
+++ b/src/processes/poisson.jl
@@ -30,7 +30,7 @@ ishomogeneous(p::PoissonProcess{<:Real}) = true
 ishomogeneous(p::PoissonProcess{<:Function}) = false
 ishomogeneous(p::PoissonProcess{<:AbstractVector}) = false
 
-default_sampling_algorithm(::PoissonProcess, g) = DiscretizedSampling()
+default_sampling_algorithm(::PoissonProcess, ::Any) = DiscretizedSampling()
 default_sampling_algorithm(p::PoissonProcess{<:Function}, g) = ThinnedSampling(default_lambda_max(p, g))
 
 function default_lambda_max(p::PoissonProcess{<:Function}, g)

--- a/src/processes/poisson.jl
+++ b/src/processes/poisson.jl
@@ -62,6 +62,16 @@ function rand_single(rng::Random.AbstractRNG, p::PoissonProcess{<:Vector}, m::Me
   PointSet(collect(pts))
 end
 
+function rand_single(rng::Random.AbstractRNG, p::PoissonProcess{<:Function}, g::Geometry, algo::DiscretizedSampling)
+  # discretize region
+  g = discretize(g)
+  m = centroid.(g)
+  λvec = p.λ.(m)
+
+  # sample point pattern
+  rand_single(rng, PoissonProcess(λvec), g, DiscretizedSampling())
+end
+
 function rand_single(rng::Random.AbstractRNG, p::PoissonProcess{<:Function}, g::GeometryOrMesh, algo::ThinnedSampling)
   # simulate a homogeneous process
   pp = rand(rng, PoissonProcess(algo.λmax), g)

--- a/src/processes/union.jl
+++ b/src/processes/union.jl
@@ -21,7 +21,7 @@ Base.union(p₁::PointProcess, p₂::PointProcess) = UnionProcess(p₁, p₂)
 
 ishomogeneous(p::UnionProcess) = ishomogeneous(p.p₁) && ishomogeneous(p.p₂)
 
-default_sampling_algorithm(::UnionProcess, g) = UnionSampling()
+default_sampling_algorithm(::UnionProcess, ::Any) = UnionSampling()
 
 function rand_single(rng::Random.AbstractRNG, p::UnionProcess, g, ::UnionSampling)
   pp₁ = rand(rng, p.p₁, g)

--- a/src/processes/union.jl
+++ b/src/processes/union.jl
@@ -21,9 +21,9 @@ Base.union(p₁::PointProcess, p₂::PointProcess) = UnionProcess(p₁, p₂)
 
 ishomogeneous(p::UnionProcess) = ishomogeneous(p.p₁) && ishomogeneous(p.p₂)
 
-default_sampling_algorithm(::UnionProcess, ::Geometry) = UnionSampling()
+default_sampling_algorithm(::UnionProcess) = UnionSampling()
 
-function rand_single(rng::Random.AbstractRNG, p::UnionProcess, g::Geometry, ::UnionSampling)
+function rand_single(rng::Random.AbstractRNG, p::UnionProcess, g, ::UnionSampling)
   pp₁ = rand(rng, p.p₁, g)
   pp₂ = rand(rng, p.p₂, g)
 

--- a/src/processes/union.jl
+++ b/src/processes/union.jl
@@ -21,7 +21,7 @@ Base.union(p₁::PointProcess, p₂::PointProcess) = UnionProcess(p₁, p₂)
 
 ishomogeneous(p::UnionProcess) = ishomogeneous(p.p₁) && ishomogeneous(p.p₂)
 
-default_sampling_algorithm(::UnionProcess) = UnionSampling()
+default_sampling_algorithm(::UnionProcess, g) = UnionSampling()
 
 function rand_single(rng::Random.AbstractRNG, p::UnionProcess, g, ::UnionSampling)
   pp₁ = rand(rng, p.p₁, g)

--- a/test/processes.jl
+++ b/test/processes.jl
@@ -44,7 +44,7 @@
     λ(s::Point2) = sum(coordinates(s) .^ 2)
     p = PoissonProcess(λ)
     for g in [seg, tri, quad, box, ball, poly, grid, mesh]
-      # simpleThinnedSampling
+      # simplethinnedsampling
       pp = rand(p, g)
       @test all(∈(g), pp)
       # thinnedsampling

--- a/test/processes.jl
+++ b/test/processes.jl
@@ -44,10 +44,13 @@
     λ(s::Point2) = sum(coordinates(s) .^ 2)
     p = PoissonProcess(λ)
     for g in [seg, tri, quad, box, ball, poly, grid, mesh]
-      # simplethinnedsampling
+      # default thinnedsampling
       pp = rand(p, g)
       @test all(∈(g), pp)
-      # thinnedsampling
+      # custom thinnedsampling using grid
+      pp = rand(p, g, algo = ThinnedSampling((10,10)))
+      @test all(∈(g), pp)
+      # custom thinnedsampling using λmax
       pp = rand(p, g, algo = ThinnedSampling(λ(Point2(12.0, 12.0))))
       @test all(∈(g), pp)
       # discretizedsampling

--- a/test/processes.jl
+++ b/test/processes.jl
@@ -48,11 +48,11 @@
       pp = rand(p, g)
       @test all(∈(g), pp)
       # custom thinnedsampling using λmax
-      pp = rand(p, g, algo = ThinnedSampling(λ(Point2(12.0, 12.0))))
+      pp = rand(p, g, algo = PointPatterns.ThinnedSampling(λ(Point2(12.0, 12.0))))
       @test all(∈(g), pp)
       # discretizedsampling
       g = discretize(g)
-      pp = rand(p, g, algo = DiscretizedSampling())
+      pp = rand(p, g, algo = PointPatterns.DiscretizedSampling())
       @test all(∈(g), g)
     end
 
@@ -61,7 +61,7 @@
       λ(s::Point2) = sum(coordinates(s) .^ 2)
       λvec = λ.(centroid.(g))
       p = PoissonProcess(λvec)
-      # discretizedsampling
+      # discretizedsampling by default
       pp = rand(p, g)
       @test all(∈(g), pp)
     end

--- a/test/processes.jl
+++ b/test/processes.jl
@@ -47,9 +47,6 @@
       # default thinnedsampling
       pp = rand(p, g)
       @test all(∈(g), pp)
-      # custom thinnedsampling using grid
-      pp = rand(p, g, algo = ThinnedSampling((10,10)))
-      @test all(∈(g), pp)
       # custom thinnedsampling using λmax
       pp = rand(p, g, algo = ThinnedSampling(λ(Point2(12.0, 12.0))))
       @test all(∈(g), pp)

--- a/test/processes.jl
+++ b/test/processes.jl
@@ -1,4 +1,18 @@
 @testset "Processes" begin
+  seg = Segment((0.0,0.0), (11.3,11.3))
+  tri = Triangle((0.0, 0.0), (5.65, 0.0), (5.65, 5.65))
+  quad = Quadrangle((0.0,0.0), (0.0,4.0), (4.0, 4.0), (4.0, 0.0))
+  box = Box((0.0,0.0), (4.0, 4.0))
+  ball = Ball((1.0,1.0), 2.25)
+  outer = Point2[(0,-4),(4,-1),(4,1.5),(0,3)]
+  hole1 = Point2[(0.2,-0.2),(1.4,-0.2),(1.4,0.6),(0.2,0.6)]
+  hole2 = Point2[(2,-0.2),(3,-0.2),(3,0.4),(2,0.4)]
+  poly = PolyArea(outer, [hole1, hole2])
+  grid = CartesianGrid((0,0), (4,4), dims = (10, 10))
+  points = Point2[(0, 0), (4.5, 0), (0, 4.2), (4, 4.3), (1.5, 1.5)]
+  connec = connect.([(1, 2, 5), (2, 4, 5), (4, 3, 5), (3, 1, 5)], Triangle)
+  mesh = SimpleMesh(points, connec)
+
   @testset "Basic" begin
     for p in [BinomialProcess(100), PoissonProcess(100.0)]
       b = Box((0.0, 1.0), (1.0, 2.0))
@@ -10,22 +24,54 @@
   end
 
   @testset "Binomial" begin
-    # TODO
+    p = BinomialProcess(10)
+    for g in [seg, tri, quad, box, ball, poly, grid, mesh]
+      pp = rand(p, g)
+      @test nelements(pp) == 10
+      @test all(∈(g), pp)
+    end
   end
 
   @testset "Poisson" begin
-    p = PoissonProcess(100.0)
-    t = Triangle((0.0, 0.0), (1.0, 0.0), (1.0, 1.0))
-    pp = rand(p, t)
-    xs = coordinates.(pp)
-    @test all(0 .≤ first.(xs) .≤ 1)
-    @test all(0 .≤ last.(xs))
+    # homogeneous
+    p = PoissonProcess(10.0)
+    for g in [seg, tri, quad, box, ball, poly, grid, mesh]
+      pp = rand(p, g)
+      @test all(∈(g), pp)
+    end
 
-    q = Quadrangle((0.0, 0.0), (1.0, 0.0), (1.0, 1.0), (0.0, 1.0))
-    pp = rand(p, q)
-    xs = coordinates.(pp)
-    @test all(0 .≤ first.(xs) .≤ 1)
-    @test all(0 .≤ last.(xs) .≤ 1)
+    # inhomogeneous with intensity function
+    λ(s::Point2) = sum(coordinates(s) .^ 2)
+    p = PoissonProcess(λ)
+    for g in [seg, tri, quad, box, ball, poly, grid, mesh]
+      # simpleThinnedSampling
+      pp = rand(p, g)
+      @test all(∈(g), pp)
+      # thinnedsampling
+      pp = rand(p, g, algo = ThinnedSampling(λ(Point2(12.0, 12.0))))
+      @test all(∈(g), pp)
+      # discretizedsampling
+      g = discretize(g)
+      pp = rand(p, g, algo = DiscretizedSampling())
+      @test all(∈(g), g)
+    end
+
+    # inhomogeneous with piecewise constant intensity
+    for g in [grid, mesh]
+      λ(s::Point2) = sum(coordinates(s) .^ 2)
+      λvec = λ.(centroid.(g))
+      p = PoissonProcess(λvec)
+      # discretizedsampling
+      pp = rand(p, g)
+      @test all(∈(g), pp)
+    end
+
+    # empty pointsets
+    for g in [seg, tri, quad, box, ball, poly, grid, mesh]
+      @test isnothing(rand(PoissonProcess(0.0), seg))
+    end
+    ps = PointSet(rand(Point2, 10))
+    @test isnothing(rand(PoissonProcess(100.0), ps))
   end
 
   @testset "Union" begin


### PR DESCRIPTION
This is still WIP, but this PR tackles JuliaEarth/GeoStats.jl#264. No need to check but suggestions are welcome.  So far:

- Old method for `ProductSampling` is being removed because we already handle that type of sampling in `Meshes.jl`, so that will be called indirectly when using `sample(g, HomogeneousSampling(n))`.
- `ThinnedSampling` is implemented assuming the user provide the `lambdamax`, this is common in other languages.

Things to add:

- Compute `lambdamax` when not provided.
- Add `PossionProcess` for intensity as CartesianGrid or a Mesh.