### PR TITLE
fix typo

### DIFF
--- a/src/thinning/random.jl
+++ b/src/thinning/random.jl
@@ -5,7 +5,7 @@
 """
     RandomThinning(p)
 
-Random thining with retention probability `p`, which can
+Random thinning with retention probability `p`, which can
 be a constant probability value in `[0,1]` or a function
 mapping a point to a probability.
 


### PR DESCRIPTION
dumped repo strings exposed a solitary typo

```
$ sed 8q PointPatterns.jl/src/thinning/random.jl
# ------------------------------------------------------------------
# Licensed under the MIT License. See LICENSE in the project root.
# ------------------------------------------------------------------

"""
    RandomThinning(p)

Random thining with retention probability `p`, which can
$ 
```