### PR TITLE
Examples and tests for ClusterProcess

### DIFF
--- a/src/processes/cluster.jl
+++ b/src/processes/cluster.jl
@@ -18,58 +18,28 @@ parent point and returns a geometry or domain for the offspring process.
 ## Examples
 
 ```julia
-import CairoMakie
-using Meshes, MeshViz
-using PointPatterns
-
 # Matern cluster process
-d = Box((0,0), (5,5))
 p = ClusterProcess(
   PoissonProcess(1),
   PoissonProcess(1000),
   parent -> Ball(parent, 0.2)
 )
-ps = rand(p, d)
-
-fig = viz(d, alpha = 0.5; axis = (;title = "Matern cluster process"))
-viz!(ps, color = :black, pointsize = 5)
-
 # Inhomogenegeous parent process with fixed number of offsprings
-
-d = Box((-2.5,-2.5), (2.5,2.5))
 p = ClusterProcess(
   PoissonProcess(s -> 1 * sum(coordinates(s) .^ 2)),
   BinomialProcess(100),
   parent -> Ball(parent, 0.2)
 )
-ps = rand(p, d)
-
-fig = viz(d, alpha = 0.5; axis = (;title = "Inhomogeneneous with fixed number of offsprings"))
-viz!(ps, color = :black, pointsize = 5)
-
 # Inhomogenegeous parent process and inhomogeneneous offspring process
-
-d = Box((0,0), (5,5))
 p = ClusterProcess(
   PoissonProcess(s -> 0.1 * sum(coordinates(s) .^ 2)),
   parent -> rand(PoissonProcess(x -> 5000 * sum((x - parent).^2)), Ball(parent, 0.5))
 )
-ps = rand(p, d)
-
-fig = viz(d, alpha = 0.5; axis = (;title = "Inhomogenegeous parent and inhomogeneneous offspring"))
-viz!(ps, color = :black, pointsize = 5)
-
 # Inhomogenegeous parent process and regularsampling
-
-d = Box((0,0), (5,5))
 p = ClusterProcess(
   PoissonProcess(s -> 0.2 * sum(coordinates(s) .^ 2)),
   parent -> PointSet(sample(Sphere(parent, 0.1), RegularSampling(10)))
 )
-ps = rand(p, d)
-
-fig = viz(d, alpha = 0.5; axis = (;title = "Inhomogenegeous parent and regular sampling"))
-viz!(ps, color = :black, pointsize = 5)
 ```
 """
 struct ClusterProcess{P<:PointProcess,F<:Function} <: PointProcess

--- a/src/processes/cluster.jl
+++ b/src/processes/cluster.jl
@@ -18,7 +18,58 @@ parent point and returns a geometry or domain for the offspring process.
 ## Examples
 
 ```julia
-# TODO
+import CairoMakie
+using Meshes, MeshViz
+using PointPatterns
+
+# Matern cluster process
+d = Box((0,0), (5,5))
+p = ClusterProcess(
+  PoissonProcess(1),
+  PoissonProcess(1000),
+  parent -> Ball(parent, 0.2)
+)
+ps = rand(p, d)
+
+fig = viz(d, alpha = 0.5; axis = (;title = "Matern cluster process"))
+viz!(ps, color = :black, pointsize = 5)
+
+# Inhomogenegeous parent process with fixed number of offsprings
+
+d = Box((-2.5,-2.5), (2.5,2.5))
+p = ClusterProcess(
+  PoissonProcess(s -> 1 * sum(coordinates(s) .^ 2)),
+  BinomialProcess(100),
+  parent -> Ball(parent, 0.2)
+)
+ps = rand(p, d)
+
+fig = viz(d, alpha = 0.5; axis = (;title = "Inhomogeneneous with fixed number of offsprings"))
+viz!(ps, color = :black, pointsize = 5)
+
+# Inhomogenegeous parent process and inhomogeneneous offspring process
+
+d = Box((0,0), (5,5))
+p = ClusterProcess(
+  PoissonProcess(s -> 0.1 * sum(coordinates(s) .^ 2)),
+  parent -> rand(PoissonProcess(x -> 5000 * sum((x - parent).^2)), Ball(parent, 0.5))
+)
+ps = rand(p, d)
+
+fig = viz(d, alpha = 0.5; axis = (;title = "Inhomogenegeous parent and inhomogeneneous offspring"))
+viz!(ps, color = :black, pointsize = 5)
+
+# Inhomogenegeous parent process and regularsampling
+
+d = Box((0,0), (5,5))
+p = ClusterProcess(
+  PoissonProcess(s -> 0.2 * sum(coordinates(s) .^ 2)),
+  parent -> PointSet(sample(Sphere(parent, 0.1), RegularSampling(10)))
+)
+ps = rand(p, d)
+
+fig = viz(d, alpha = 0.5; axis = (;title = "Inhomogenegeous parent and regular sampling"))
+viz!(ps, color = :black, pointsize = 5)
 ```
 """
 struct ClusterProcess{P<:PointProcess,F<:Function} <: PointProcess

--- a/src/processes/cluster.jl
+++ b/src/processes/cluster.jl
@@ -17,25 +17,38 @@ parent point and returns a geometry or domain for the offspring process.
 
 ## Examples
 
+Matern cluster process:
+
 ```julia
-# Matern cluster process
 p = ClusterProcess(
   PoissonProcess(1),
   PoissonProcess(1000),
   parent -> Ball(parent, 0.2)
 )
-# Inhomogenegeous parent process with fixed number of offsprings
+```
+
+Inhomogenegeous parent process with fixed number of offsprings:
+
+```julia
 p = ClusterProcess(
   PoissonProcess(s -> 1 * sum(coordinates(s) .^ 2)),
   BinomialProcess(100),
   parent -> Ball(parent, 0.2)
 )
-# Inhomogenegeous parent process and inhomogeneneous offspring process
+```
+
+Inhomogenegeous parent process and inhomogeneneous offspring process:
+
+```julia
 p = ClusterProcess(
   PoissonProcess(s -> 0.1 * sum(coordinates(s) .^ 2)),
   parent -> rand(PoissonProcess(x -> 5000 * sum((x - parent).^2)), Ball(parent, 0.5))
 )
-# Inhomogenegeous parent process and regularsampling
+```
+
+Inhomogenegeous parent process and regularsampling:
+
+```julia
 p = ClusterProcess(
   PoissonProcess(s -> 0.2 * sum(coordinates(s) .^ 2)),
   parent -> PointSet(sample(Sphere(parent, 0.1), RegularSampling(10)))

--- a/test/processes.jl
+++ b/test/processes.jl
@@ -58,12 +58,12 @@
   @testset "Inhibition" begin end
 
   @testset "Cluster" begin
-    offspring1 = parent -> rand(BinomialProcess(10), Ball(parent, 0.2))
-    offspring2 = parent -> rand(PoissonProcess(100), Ball(parent, 0.2))
-    offspring3 = parent -> rand(PoissonProcess(x -> 100 * sum((x - parent).^2)), Ball(parent, 0.5))
-    offspring4 = parent -> PointSet(sample(Sphere(parent, 0.1), RegularSampling(10)))
-    offspringfuns = [offspring1, offspring2, offspring3, offspring4]
-    for p in procs, ofun in offspringfuns, g in geoms
+    ofun1 = parent -> rand(BinomialProcess(10), Ball(parent, 0.2))
+    ofun2 = parent -> rand(PoissonProcess(100), Ball(parent, 0.2))
+    ofun3 = parent -> rand(PoissonProcess(x -> 100 * sum((x - parent).^2)), Ball(parent, 0.5))
+    ofun4 = parent -> PointSet(sample(Sphere(parent, 0.1), RegularSampling(10)))
+    ofuns = [ofun1, ofun2, ofun3, ofun4]
+    for p in procs, ofun in ofuns, g in geoms
       cp = ClusterProcess(p, ofun)
       pp = rand(cp, g)
       @test all(∈(g), pp)

--- a/test/processes.jl
+++ b/test/processes.jl
@@ -57,7 +57,18 @@
 
   @testset "Inhibition" begin end
 
-  @testset "Cluster" begin end
+  @testset "Cluster" begin
+    offspring1 = parent -> rand(BinomialProcess(10), Ball(parent, 0.2))
+    offspring2 = parent -> rand(PoissonProcess(100), Ball(parent, 0.2))
+    offspring3 = parent -> rand(PoissonProcess(x -> 100 * sum((x - parent).^2)), Ball(parent, 0.5))
+    offspring4 = parent -> PointSet(sample(Sphere(parent, 0.1), RegularSampling(10)))
+    offspringfuns = [offspring1, offspring2, offspring3, offspring4]
+    for p in procs, ofun in offspringfuns, g in geoms
+      cp = ClusterProcess(p, ofun)
+      pp = rand(cp, g)
+      @test all(∈(g), pp)
+    end
+  end
 
   @testset "Union" begin
     b = Box((0.0, 0.0), (100.0, 100.0))


### PR DESCRIPTION
Tests are currently breaking when working with CartesianGrids and SimpleMeshes due to JuliaGeometry/Meshes.jl#477. Also, let me know if I should remove the MeshViz code.