### PR TITLE
fix bug in piecewise algorithm

### DIFF
--- a/src/processes/poisson.jl
+++ b/src/processes/poisson.jl
@@ -47,15 +47,12 @@ function randsingle(rng::Random.AbstractRNG, p::PoissonProcess{<:Function}, g)
   pset = randsingle(rng, PoissonProcess(λmax), g)
 
   # thin point pattern
-  isnothing(pset) ? nothing : thin(pset, RandomThinning(x -> p.λ(x) / λmax))
+  isnothing(pset) ? nothing : PointSet(collect(thin(pset, RandomThinning(x -> p.λ(x) / λmax))))
 end
-
-randsingle(rng::Random.AbstractRNG, p::PoissonProcess{<:Function}, d::Domain) =
-  randsingle(rng, PoissonProcess(p.λ.(centroid.(d))), d)
 
 function randsingle(rng::Random.AbstractRNG, p::PoissonProcess{<:AbstractVector}, d::Domain)
   # simulate number of points
-  λ = p.λ .* measure(d)
+  λ = p.λ .* measure.(d)
   n = rand(rng, Poisson(sum(λ)))
 
   # simulate point pattern


### PR DESCRIPTION
Fix the following:

1. Bug introduced `randsingle` for piecewise constant intensity.
2. Return a PoinSet in `randsingle` for intensity function (after thinning). It was returning a view.
3. Remove `randsingle(rng::Random.AbstractRNG, p::PoissonProcess{<:Function}, d::Domain)` because we do not need to assume that the user wants a piecewise intensity. They can already do it providing a vector as intensity.